### PR TITLE
Change PlatformUtils to a class

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,4 @@
  */
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-withCredentials([string(credentialsId: 'atlas_gradle_coveralls_token', variable: 'coveralls_token')]) {
-    buildJavaLibraryOSSRH()
-}
+buildJavaLibraryOSSRH()

--- a/src/main/groovy/com/wooga/gradle/PlatformUtils.groovy
+++ b/src/main/groovy/com/wooga/gradle/PlatformUtils.groovy
@@ -2,7 +2,7 @@ package com.wooga.gradle
 
 import groovy.json.StringEscapeUtils
 
-trait PlatformUtilsImpl {
+class PlatformUtils {
 
     private static final String _osName = System.getProperty("os.name").toLowerCase()
     private static final String _osArch = System.getProperty("os.arch").toLowerCase()
@@ -67,7 +67,4 @@ trait PlatformUtilsImpl {
     static String getUnixUserHomePath() {
         System.getProperty("user.home")
     }
-}
-
-class PlatformUtils implements PlatformUtilsImpl {
 }


### PR DESCRIPTION
## Description

The `PlatformUtils` used to be a trait object with only static methods in it. From the usage I feel way better to static import the needed methods when needed instead of implementing a trait.

## Changes

* ![CHANGE] make `PlatformUtils` a class
* ![REMOVE] `PlatformUtilsImpl`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
