### PR TITLE
Promote PropertyUtils from gradle-commons-test

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -28,6 +28,10 @@ import org.gradle.api.provider.ProviderFactory
 import java.util.concurrent.Callable
 
 
+/**
+ * An utility object that is used for easily querying the system environment
+ * or a project's properties.
+ */
 class PropertyLookup {
     /**
      * Provided environment keys
@@ -54,26 +58,50 @@ class PropertyLookup {
      */
     String prefix = ""
 
+    /**
+     * A lookup that has multiple environment and property keys
+     */
     PropertyLookup(List<String> environmentKeys, List<String> propertyKeys, Object defaultValue) {
         this.environmentKeys = environmentKeys
         this.propertyKeys = propertyKeys
         this.defaultValue = defaultValue
     }
 
+    /**
+     * A lookup with multiple environment keys and a single property key
+     */
     PropertyLookup(List<String> environmentKeys, String propertyKey, Object defaultValue) {
         this(environmentKeys, [propertyKey], defaultValue)
     }
 
+    /**
+     * A lookup with multiple property keys and a single environment key
+     */
     PropertyLookup(String environmentKey, List<String> propertyKeys, Object defaultValue) {
         this([environmentKey], propertyKeys, defaultValue)
     }
 
+    /**
+     * A lookup with a single property key and an environment key
+     */
     PropertyLookup(String environmentKey, String propertyKey, Object defaultValue) {
         this([environmentKey], [propertyKey], defaultValue)
     }
 
+    /**
+     * A special-case lookup that just returns the default value
+     */
     PropertyLookup(Object defaultValue) {
         this([], [], defaultValue)
+    }
+
+    /**
+     * A property lookup that generates the environment key from the given property key,
+     * using a set convention
+     */
+    static PropertyLookup WithEnvironmentKeyFromProperty(String propertyKey, Object defaultValue) {
+        String envKey = PropertyUtils.envNameFromProperty(propertyKey)
+        return new PropertyLookup(envKey, propertyKey, defaultValue)
     }
 
     /**

--- a/src/main/groovy/com/wooga/gradle/PropertyUtils.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyUtils.groovy
@@ -1,0 +1,59 @@
+package com.wooga.gradle
+
+class PropertyUtils {
+
+    /**
+     * @param extensionName The name of the extension the property belongs to
+     * @param property The name of the property
+     * @return
+     */
+    static String envNameFromProperty(String extensionName, String property) {
+        envNameFromProperty(extensionName + "." + property)
+    }
+
+    /**
+     * @param property The full path of the property
+     * @return A generated environment key based from the property path
+     */
+    static String envNameFromProperty(String property) {
+        property.replaceAll(/([A-Z.])/, '_$1').replaceAll(/[.]/, '').toUpperCase()
+    }
+
+    /**
+     * @param input An input string with conventional delimiters (such as -, _)
+     * @return A string, in camel case. (helloThereBrownCow)
+     */
+    static String toCamelCase(String input) {
+        input.replaceAll(/\(\)/,"").replaceAll(/((\/|-|_|\.)+)([\w])/, { all, delimiterAll, delimiter, firstAfter -> "${firstAfter.toUpperCase()}" })
+    }
+
+    /**
+     * Returns the {@code Provider} set method string for the given property name.
+     * This method simply appends {@code .set} to the provided property string.
+     *
+     * @param propertyName The property name to convert to a {@code Provider} set method
+     * @return The {@code Provider} set method string for the given property name.
+     */
+    static String toProviderSet(String propertyName) {
+        "${propertyName}.set"
+    }
+
+    /**
+     * Returns the setter method string for the given property name.
+     * <p>
+     * If the property name is fully qualified it will split at `.`
+     * and append the setter prefix to the last item.
+     * <p>
+     * {@code foo.bar.baz -> foo.bar.setBaz}
+     * @param propertyName The property name to convert to a setter
+     * @return The setter method string for the given property name.
+     */
+    static String toSetter(String propertyName) {
+        def propertyChain = propertyName.split(/\./).reverse().toList()
+        if (propertyChain.size() > 1) {
+            return (propertyChain.tail().reverse() << toSetter(propertyChain.head())).join(".")
+        }
+        "set${propertyChain.head().capitalize()}"
+    }
+}
+

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupTest.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupTest.groovy
@@ -77,4 +77,23 @@ class PropertyLookupTest extends Specification {
         expected = "7"
     }
 
+    def "creates lookup with generated environment key"() {
+        when:
+        def lookup =  PropertyLookup.WithEnvironmentKeyFromProperty (propertyKey, defaultValue)
+
+        then:
+        lookup.environmentKeys.size() == 1
+        lookup.environmentKeys[0] == expectedEnvironmentKey
+        def actual = lookup.getValue(props, env)
+        actual == expected
+
+        where:
+        propertyKey | expectedEnvironmentKey
+        "bread.ham" | "BREAD_HAM"
+        defaultValue = "FOO"
+        expected = 7
+        props = ["bread.ham": 7]
+        env = ["BREAD_HAM": 7]
+    }
+
 }

--- a/src/test/groovy/com/wooga/gradle/PropertyUtilsSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyUtilsSpec.groovy
@@ -1,0 +1,58 @@
+package com.wooga.gradle
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PropertyUtilsSpec extends Specification {
+
+    def "environment name is converted from extension and property name"() {
+        when:
+        def environmentName = PropertyUtils.envNameFromProperty(extensionName, propertyName)
+
+        then:
+        environmentName == expectedEnvironmentName
+
+        where:
+        extensionName | propertyName | expectedEnvironmentName
+        "foobar"      | "kat.zen"    | "FOOBAR_KAT_ZEN"
+    }
+
+    def "environment name is converted from property name"() {
+        when:
+        def environmentName = PropertyUtils.envNameFromProperty(propertyName)
+
+        then:
+        environmentName == expectedEnvironmentName
+
+        where:
+        propertyName | expectedEnvironmentName
+        "kat.zen"    | "KAT_ZEN"
+    }
+
+    @Unroll
+    def "toProviderSet returns a provider set method invocation #expectedResult from property #property"() {
+        expect:
+        PropertyUtils.toProviderSet(property) == expectedResult
+
+        where:
+        property      | expectedResult
+        "foo"         | "foo.set"
+        "foo.bar"     | "foo.bar.set"
+        "foo.bar.baz" | "foo.bar.baz.set"
+    }
+
+    @Unroll
+    def "toSetter returns a setter method invocation #expectedResult from property #property"() {
+        expect:
+        PropertyUtils.toSetter(property) == expectedResult
+
+        where:
+        property      | expectedResult
+        "foo"         | "setFoo"
+        "foo.bar"     | "foo.setBar"
+        "foo.bar.baz" | "foo.bar.setBaz"
+
+    }
+
+
+}


### PR DESCRIPTION
## Description

Adds PropertyUtils from gradle-commons-test and a newer static constructor in PropertyLookup that composes the environment key from the property key name.


- PropertyUtils is quite useful and can be used by more than test classes
- The newer static constructor for PropertyLookup uses a PropertyUtils method that follows convention

## Changes
* ![ADD] PropertyUtils
* ![UPDATE] PropertyLookup

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
