### PR TITLE
Add arguments spec, for adding arguments onto a task (both internally…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
         }
     }
     testImplementation 'com.github.stefanbirkner:system-rules:1.18.0'
+    testImplementation 'com.wooga.gradle:gradle-commons-test:0.3.0'
 
     api 'org.apache.commons:commons-math3:3.6.1'
 }

--- a/src/main/groovy/com/wooga/gradle/ArgumentsSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/ArgumentsSpec.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.gradle
+
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+
+/**
+ * Provides a task with properties for configuring arguments to be used during execution.
+ */
+trait ArgumentsSpec extends BaseSpec {
+
+    private Provider<List<String>> internalArguments = providers.provider { new ArrayList<String>() }
+
+    /**
+     * @return Internal arguments, which are set through a provider.
+     * (The most common use being arguments generated before execution of a task)
+     */
+    @Internal
+    private Provider<List<String>> getInternalArguments() {
+        internalArguments
+    }
+
+    void setInternalArguments(Provider<List<String>> provider) {
+        internalArguments = provider;
+    }
+
+    private final ListProperty<String> additionalArguments = objects.listProperty(String)
+
+    /**
+     * @return Additional arguments to be consumed by the execution of a task.
+     * (The most common use case being that of users supplying them during task configuration)
+     */
+    @Input
+    ListProperty<String> getAdditionalArguments() {
+        additionalArguments
+    }
+
+    void setAdditionalArguments(Iterable<String> value) {
+        additionalArguments.set(value)
+    }
+
+    void setAdditionalArguments(String value) {
+        additionalArguments.set([value])
+    }
+
+    void setAdditionalArguments(Provider<? extends Iterable<String>> value) {
+        additionalArguments.set(value)
+    }
+
+    void argument(String value) {
+        additionalArguments.add(value)
+    }
+
+    void arguments(Iterable<String> value) {
+        additionalArguments.addAll(value)
+    }
+
+    void arguments(String... value) {
+        arguments(value.toList())
+    }
+
+    /**
+     * @return Retrieves both {@code internalArguments} and {@code additionalArguments}, to be consumed by a task.
+     */
+    Provider<List<String>> getArguments() {
+        providers.provider({
+            List<String> result = new ArrayList<String>()
+            result.addAll(internalArguments.get())
+            result.addAll(additionalArguments.get())
+            result
+        })
+    }
+
+    private final MapProperty<String, ?> environment = objects.mapProperty(String, Object)
+
+    /**
+     * @return Used for populating the environment to be used during task execution.
+     */
+    @Internal
+    MapProperty<String, ?> getEnvironment() {
+        environment
+    }
+
+    /**
+     * Sets the task's environment (which is used during execution) from the System's environment ({@code System.env})
+     */
+    void setEnvironmentDefaults() {
+        environment.putAll(providers.provider({ System.getenv() }))
+    }
+
+}

--- a/src/test/groovy/com/wooga/gradle/ArgumentsSpecTest.groovy
+++ b/src/test/groovy/com/wooga/gradle/ArgumentsSpecTest.groovy
@@ -1,0 +1,166 @@
+package com.wooga.gradle
+
+import com.wooga.gradle.test.MapPropertyQueryTaskWriter
+import com.wooga.gradle.test.PropertyQueryTaskWriter
+import org.gradle.api.Action
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+import spock.lang.Unroll
+
+class ArgumentsUsingTask extends MockTask implements ArgumentsSpec {
+
+    ArgumentsUsingTask() {
+        internalArguments = project.provider({ composeCoolArguments() })
+    }
+
+    List<String> composeCoolArguments() {
+        return ["foo", "bar"]
+    }
+
+    @TaskAction
+    void run() {
+        def _executable = MockIntegrationSpec.generateBatchWrapper("superkatzen", true)
+        def _arguments = arguments.get()
+        def _environment = environment.get()
+
+        ExecResult execResult = project.exec(new Action<ExecSpec>() {
+            @Override
+            void execute(ExecSpec exec) {
+                exec.with {
+                    executable _executable
+                    args = _arguments
+                    environment = _environment
+                }
+            }
+        })
+    }
+}
+
+class ArgumentsSpecTest extends MockTaskIntegrationSpec<ArgumentsUsingTask> {
+
+    def "runs task, generating composed arguments"() {
+        when:
+        def result = runTasksSuccessfully(subjectUnderTestName)
+        then:
+        result.success
+    }
+
+    @Unroll
+    def "can configure arguments with #method #message"() {
+        given: "a custom task"
+        buildFile << """
+            ${subjectUnderTestName} {
+                arguments(["--test", "value"])
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${subjectUnderTestName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def query = new PropertyQueryTaskWriter("${subjectUnderTestName}.${property}")
+        query.write(buildFile)
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, expectedValue)
+
+        where:
+        method                    | rawValue         | type                      | append | expectedValue
+        "argument"                | "--foo"          | "String"                  | true   | ["--test", "value", "--foo"]
+        "arguments"               | ["--foo", "bar"] | "List<String>"            | true   | ["--test", "value", "--foo", "bar"]
+        "arguments"               | ["--foo", "bar"] | "String[]"                | true   | ["--test", "value", "--foo", "bar"]
+        "setAdditionalArguments"  | ["--foo", "bar"] | "List<String>"            | false  | ["--foo", "bar"]
+        "setAdditionalArguments"  | ["--foo", "bar"] | "Provider<List<String>>"  | false  | ["--foo", "bar"]
+        "additionalArguments.set" | ["--foo", "bar"] | "List<String>"            | false  | ["--foo", "bar"]
+        // TODO: Add again once bug on commons-test wrapValueBasedOnType is fixed
+        //"additionalArguments.set" | ["--foo", "bar"] | "Provider<List<String>>>" | false  | ["--foo", "bar"]
+
+        property = "additionalArguments"
+        value = wrapValueBasedOnType(rawValue, type)
+        message = (append) ? "which appends arguments" : "which replaces arguments"
+    }
+
+    @Unroll
+    def "set environment variable #rawValue for task exec"() {
+        given: "some clean environment variables"
+        if (!PlatformUtils.windows) {
+            def envNames = System.getenv().keySet().toArray()
+            environmentVariables.clear(*envNames)
+        }
+
+        and: "a test value in system env"
+        initialValue.each { key, value ->
+            environmentVariables.set(key, value)
+        }
+
+        and: "an initial environment"
+        appendToSubjectTask("setEnvironmentDefaults()")
+
+        and: "an overridden environment"
+        appendToSubjectTask("$method($value)")
+
+        and: "some values in the user environment"
+        environmentVariables.set("USER_A", "foo")
+
+        when:
+        def query = new MapPropertyQueryTaskWriter(propertyPath)
+        query.write(buildFile)
+        def result = runTasksSuccessfully(subjectUnderTestName, query.taskName)
+
+        then:
+        query.contains(result, rawValue)
+
+        where:
+        property      | useSetter | rawValue
+        "environment" | true      | ["A": "foo"]
+        "environment" | false     | ["A": "bar"]
+        "environment" | true      | ["A": 7]
+        "environment" | false     | ["A": 7]
+        "environment" | true      | ["A": file("foo.bar")]
+        "environment" | false     | ["A": file("foo.bar")]
+        "environment" | true      | ["A": true]
+        "environment" | false     | ["A": false]
+
+        initialValue = ["B": "5", "C": "7"]
+        method = (useSetter) ? "set${property.capitalize()}" : "${property}.set"
+        value = wrapValueBasedOnType(rawValue, Map)
+        propertyPath = "${subjectUnderTestName}.environment"
+    }
+
+    def "adds environment for task exec"() {
+        given: "some clean environment variables"
+        if (!PlatformUtils.windows) {
+            def envNames = System.getenv().keySet().toArray()
+            environmentVariables.clear(*envNames)
+        }
+
+        and: "an initial environment"
+        appendToSubjectTask("setEnvironmentDefaults()")
+
+        and: "a test value in system env"
+        initialValue.each { key, value ->
+            environmentVariables.set(key, value)
+        }
+
+        appendToSubjectTask("$method(${wrapValueBasedOnType(rawValue, Map)})")
+
+        when:
+        def query = new MapPropertyQueryTaskWriter(propertyPath)
+        query.write(buildFile)
+        def result = runTasksSuccessfully(subjectUnderTestName, query.taskName)
+
+        then:
+        query.contains(result, initialValue, rawValue)
+
+        where:
+        method               | rawValue   | initialValue
+        "environment.putAll" | ["A": "7"] | ["B": "5"]
+
+        value = wrapValueBasedOnType(rawValue, Map)
+        propertyPath = "${subjectUnderTestName}.environment"
+    }
+}

--- a/src/test/groovy/com/wooga/gradle/MockIntegrationSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/MockIntegrationSpec.groovy
@@ -10,7 +10,7 @@ import org.junit.contrib.java.lang.system.ProvideSystemProperty
 import java.lang.reflect.ParameterizedType
 import java.nio.file.Files
 
-class MockIntegrationSpec extends IntegrationSpec {
+class MockIntegrationSpec extends com.wooga.gradle.test.IntegrationSpec {
 
     @Rule
     ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")


### PR DESCRIPTION
## Description

Adds the `ArgumentsSpec`, which provides properties for setting arguments to be consumed during task execution.
These are:

* Internal arguments, set by a provider which generates them 
* Additional arguments, to be supplied by the user during task configuration

## Changes
* ![ADD] ArgumentsSpec

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
