### PR TITLE
Fix missing/wrong gradle property annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,25 @@ dependencies {
     api 'org.apache.commons:commons-math3:3.6.1'
 }
 
+JavaPluginConvention javaConvention = (JavaPluginConvention)project.getConvention().getPlugin(JavaPluginConvention.class);
+SourceSet sourceSet = javaConvention.getSourceSets().getByName("test")
+
+TaskProvider<ValidatePlugins> validatorTask = tasks.register("validateMockedPlugins", ValidatePlugins) { task ->
+    task.setGroup("Plugin development");
+    task.setDescription("Validates the mocked plugins by checking parameter annotations on mocked task and artifact transform types etc.");
+    task.getOutputFile().set(layout.getBuildDirectory().file("reports/plugin-development/validation-report.txt"));
+    task.getClasses().setFrom(provider {
+        return sourceSet.getOutput().getClassesDirs();
+    })
+    task.getClasspath().setFrom(provider {
+        return sourceSet.getCompileClasspath();
+    })
+}
+
+tasks.named("check", {
+    it.dependsOn(validatorTask)
+})
+
 // TODO: Remove in the future when nebule-release is removed
 List<String> cliTasks = project.rootProject.gradle.startParameter.taskNames
 if (cliTasks.contains("rc")) {

--- a/src/main/groovy/com/wooga/gradle/ArgumentsSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/ArgumentsSpec.groovy
@@ -80,6 +80,7 @@ trait ArgumentsSpec extends BaseSpec {
     /**
      * @return Retrieves both {@code internalArguments} and {@code additionalArguments}, to be consumed by a task.
      */
+    @Input
     Provider<List<String>> getArguments() {
         providers.provider({
             List<String> result = new ArrayList<String>()

--- a/src/main/groovy/com/wooga/gradle/BaseSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/BaseSpec.groovy
@@ -13,7 +13,6 @@ import javax.inject.Inject
  */
 trait BaseSpec {
     @Inject
-    @Internal
     ProjectLayout getLayout() {
         throw new Exception("ProjectLayout is supposed to be injected here by gradle")
     }
@@ -24,13 +23,11 @@ trait BaseSpec {
     }
 
     @Inject
-    @Internal
     ProviderFactory getProviders() {
         throw new Exception("ProviderFactory is supposed to be injected here by gradle")
     }
 
     @Inject
-    @Internal
     ObjectFactory getObjects() {
         throw new Exception("ObjectFactory is supposed to be injected here by gradle")
     }

--- a/src/test/groovy/com/wooga/gradle/MockIntegrationSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/MockIntegrationSpec.groovy
@@ -1,6 +1,6 @@
 package com.wooga.gradle
 
-import nebula.test.IntegrationSpec
+
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -10,7 +10,7 @@ import org.junit.contrib.java.lang.system.ProvideSystemProperty
 import java.lang.reflect.ParameterizedType
 import java.nio.file.Files
 
-class MockIntegrationSpec extends com.wooga.gradle.test.IntegrationSpec {
+abstract class MockIntegrationSpec extends com.wooga.gradle.test.IntegrationSpec {
 
     @Rule
     ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
@@ -58,7 +58,7 @@ class MockIntegrationSpec extends com.wooga.gradle.test.IntegrationSpec {
     }
 }
 
-class MockTaskIntegrationSpec<T extends MockTask> extends MockIntegrationSpec {
+abstract class MockTaskIntegrationSpec<T extends MockTask> extends MockIntegrationSpec {
 
     Class<T> getSubjectUnderTestClass() {
         if (!_sutClass) {


### PR DESCRIPTION
## Description

Gradle is very picky when it comes to the correct way of declaring properties for tasks. Our `BaseSpec` uses `@Inject` getters which are not allowed to also carry `@Internal`
annotations.

I also added the missing annoation for `getArguments` in `ArgumentSpec`

Last but not least I added a validation task from the gradle `gradle-java-plugin` plugin to validate our mocked plugin/task classes.

## Changes

* ![FIX] incorrect property annotations in `BaseSpec`
* ![FIX] missing property annotation for `getArguments` in `ArgumentsSpec`
* ![IMPROVE] gradle property annotiation checks with task `validateMockedPlugins`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
