### PR TITLE
Fix logToStdout provider access in getOutputStream

### DIFF
--- a/src/main/groovy/com/wooga/gradle/io/OutputStreamSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/io/OutputStreamSpec.groovy
@@ -26,7 +26,7 @@ trait OutputStreamSpec extends BaseSpec {
     OutputStream getOutputStream(File logFile) {
         OutputStream outputStream
         // If logging to stdout is enabled
-        if (logToStdout.get()) {
+        if (logToStdout.isPresent() && logToStdout.get()) {
             TextStream handler = new ForkTextStream()
             String lineSeparator = SystemProperties.getInstance().getLineSeparator()
             outputStream = new LineBufferingOutputStream(handler, lineSeparator)


### PR DESCRIPTION
## Description

The implementation of `OutputStreamSpec#getOutputStream` expects the property `logToStdout` to be always set which may or may not be the case. I added an extra check to evaluate only if the property is filled.

## Changnes

* ![FIX] `logToStout` provider access in `getOutputStream`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
