### PR TITLE
Add missing test case for ArgumentsSpec

### DIFF
--- a/src/test/groovy/com/wooga/gradle/ArgumentsSpecTest.groovy
+++ b/src/test/groovy/com/wooga/gradle/ArgumentsSpecTest.groovy
@@ -69,15 +69,14 @@ class ArgumentsSpecTest extends MockTaskIntegrationSpec<ArgumentsUsingTask> {
         query.matches(result, expectedValue)
 
         where:
-        method                    | rawValue         | type                      | append | expectedValue
-        "argument"                | "--foo"          | "String"                  | true   | ["--test", "value", "--foo"]
-        "arguments"               | ["--foo", "bar"] | "List<String>"            | true   | ["--test", "value", "--foo", "bar"]
-        "arguments"               | ["--foo", "bar"] | "String[]"                | true   | ["--test", "value", "--foo", "bar"]
-        "setAdditionalArguments"  | ["--foo", "bar"] | "List<String>"            | false  | ["--foo", "bar"]
-        "setAdditionalArguments"  | ["--foo", "bar"] | "Provider<List<String>>"  | false  | ["--foo", "bar"]
-        "additionalArguments.set" | ["--foo", "bar"] | "List<String>"            | false  | ["--foo", "bar"]
-        // TODO: Add again once bug on commons-test wrapValueBasedOnType is fixed
-        //"additionalArguments.set" | ["--foo", "bar"] | "Provider<List<String>>>" | false  | ["--foo", "bar"]
+        method                    | rawValue         | type                     | append | expectedValue
+        "argument"                | "--foo"          | "String"                 | true   | ["--test", "value", "--foo"]
+        "arguments"               | ["--foo", "bar"] | "List<String>"           | true   | ["--test", "value", "--foo", "bar"]
+        "arguments"               | ["--foo", "bar"] | "String[]"               | true   | ["--test", "value", "--foo", "bar"]
+        "setAdditionalArguments"  | ["--foo", "bar"] | "List<String>"           | false  | ["--foo", "bar"]
+        "setAdditionalArguments"  | ["--foo", "bar"] | "Provider<List<String>>" | false  | ["--foo", "bar"]
+        "additionalArguments.set" | ["--foo", "bar"] | "List<String>"           | false  | ["--foo", "bar"]
+        "additionalArguments.set" | ["--foo", "bar"] | "Provider<List<String>>" | false  | ["--foo", "bar"]
 
         property = "additionalArguments"
         value = wrapValueBasedOnType(rawValue, type)


### PR DESCRIPTION
## Description
Add missing test case for the arguments spec.

## Changes
* ![ADD] Missing test case for arguments spec

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
