### PR TITLE
Expose override the default value for a property lookup

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -50,13 +50,20 @@ class PropertyLookup {
     /**
      * If it can't find the value from either environment or property map, it will return this one
      */
-    private final Object defaultValue
+    private Object defaultValue
 
     /**
      * @return The default value for this property
      */
     Object getDefaultValue() {
         extractValue(defaultValue)
+    }
+
+    /**
+     * Sets the default value for this property
+     */
+    void setDefaultValue(Object value) {
+        defaultValue = value
     }
 
     /**
@@ -127,9 +134,11 @@ class PropertyLookup {
     Object getValue(Map<String, ?> properties, Map<String, ?> environment = null) {
 
         // First, we look among properties
-        for (key in propertyKeys) {
-            if (properties.containsKey(key)) {
-                return extractValue(properties.get("${prefix}${key}".toString()))
+        if (properties != null) {
+            for (key in propertyKeys) {
+                if (properties.containsKey(key)) {
+                    return extractValue(properties.get("${prefix}${key}".toString()))
+                }
             }
         }
 
@@ -263,9 +272,9 @@ class PropertyLookup {
      */
     Provider<RegularFile> getFileValueProvider(ProviderFactory factory, ProjectLayout layout, Map<String, ?> properties, Map<String, ?> env = null) {
         layout.buildDirectory.file(
-                factory.provider({
-                    getValueAsString(properties, env)
-                })
+            factory.provider({
+                getValueAsString(properties, env)
+            })
         )
     }
 
@@ -283,9 +292,9 @@ class PropertyLookup {
      */
     Provider<Directory> getDirectoryValueProvider(ProviderFactory factory, ProjectLayout layout, Map<String, ?> properties, Map<String, ?> env = null) {
         layout.buildDirectory.dir(
-                factory.provider({
-                    getValueAsString(properties, env)
-                })
+            factory.provider({
+                getValueAsString(properties, env)
+            })
         )
     }
 

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupTest.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupTest.groovy
@@ -219,4 +219,26 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         SuperCoolEnum.cold | SuperCoolEnum.cold
     }
 
+    def "overrides default value set on property"() {
+
+        given: "a constructed lookup"
+        def lookup = new PropertyLookup(defaultValue)
+
+        when: "a generated provider"
+        def provider = lookup.getStringValueProvider(project)
+
+        then: "return the initial default value"
+        defaultValue == provider.get()
+
+        when: "overriding the default value"
+        lookup.defaultValue = newDefaultValue
+
+        then: "return the new default value"
+        newDefaultValue == provider.get()
+
+        where:
+        defaultValue = "FOO"
+        newDefaultValue = 'BAR'
+    }
+
 }


### PR DESCRIPTION
## Description

Exposes the setter for the default value in the property lookup. This will allow convention defaults to be overridden externally.

## Changes
* ![ADD] `PropertyLookup` defaultValue setter
 
[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
