### PR TITLE
Add an enum value provider method on PropertyLookup

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -323,4 +323,18 @@ class PropertyLookup {
             getValueProvider(project.providers, project.properties, parseFunc, System.getenv(), defaultValue)
         }).flatMap({ it })
     }
+
+    /**
+     * @return A provider which returns an enum of type {#code T}, casting from string when needed
+     */
+    public <T> Provider<T> getEnumValueProvider(Project project, Class<T> enumClass, Object defaultValue = null) {
+        if (!enumClass.enum){
+            throw new Exception("${enumClass} is not an enumeration type!")
+        }
+
+        getObjectValueProvider(project, defaultValue).map({
+            def enumValue = enumClass.invokeMethod("valueOf", it.toString())
+            enumValue
+        })  as Provider<T>
+    }
 }

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
@@ -187,4 +187,26 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         newDefaultValue = 'BAR'
     }
 
+    @Unroll
+    def "gets enum value #expected from enum provider"() {
+
+        given: "a property lookup"
+        def lookup = new PropertyLookup(value)
+
+        and: "a provider for it"
+        def provider = lookup.getEnumValueProvider(project, SuperCoolEnum.class, defaultValue)
+
+        when:
+        def actual = provider.get()
+
+        then:
+        actual == expected
+
+        where:
+        value              | defaultValue      | expected
+        "hot"              | null              | SuperCoolEnum.hot
+        SuperCoolEnum.cold | null              | SuperCoolEnum.cold
+        "hot"              | "cold"            | SuperCoolEnum.cold
+        SuperCoolEnum.cold | SuperCoolEnum.hot | SuperCoolEnum.hot
+    }
 }


### PR DESCRIPTION
## Description

Add a provider that works for enum types, that automatically converts strings to the enum type.

## Changes
* ![ADD] `PropertyLookup` enum value provider

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
