### PR TITLE
Add snyk monitoring [ATLAS-668]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,4 +16,9 @@
  */
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-buildJavaLibraryOSSRH()
+withCredentials([string(credentialsId: 'snyk-wdk-token', variable: 'SNYK_TOKEN')])
+{
+    withEnv(['SNYK_ORG_NAME=wooga-pipeline', 'SNYK_AUTO_DOWNLOAD=YES']) {
+        buildJavaLibraryOSSRH()
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,10 @@ plugins {
     id 'signing'
     id 'nebula.release' version '15.2.0'
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.8.2'
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-wdk-java" version "0.3.0"
+    id "net.wooga.cve-dependency-resolution" version "0.3.0"
 }
 
 group 'com.wooga.gradle'
@@ -36,7 +38,7 @@ repositories {
 dependencies {
     implementation localGroovy()
     implementation gradleApi()
-    implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.google.guava:guava:30.0-jre'
 
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
     testImplementation 'junit:junit:4.13'
@@ -47,9 +49,13 @@ dependencies {
         }
     }
     testImplementation 'com.github.stefanbirkner:system-rules:1.18.0'
-    testImplementation 'com.wooga.gradle:gradle-commons-test:0.3.0'
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2)'
 
     api 'org.apache.commons:commons-math3:3.6.1'
+}
+
+snyk {
+    projectEnvironment = "distributed"
 }
 
 JavaPluginConvention javaConvention = (JavaPluginConvention)project.getConvention().getPlugin(JavaPluginConvention.class);

--- a/src/test/groovy/com/wooga/gradle/ArgumentsSpecTest.groovy
+++ b/src/test/groovy/com/wooga/gradle/ArgumentsSpecTest.groovy
@@ -92,8 +92,8 @@ class ArgumentsSpecTest extends MockTaskIntegrationSpec<ArgumentsUsingTask> {
         }
 
         and: "a test value in system env"
-        initialValue.each { key, value ->
-            environmentVariables.set(key, value)
+        initialValue.each { key, v ->
+            environmentVariables.set(key, v)
         }
 
         and: "an initial environment"
@@ -141,8 +141,8 @@ class ArgumentsSpecTest extends MockTaskIntegrationSpec<ArgumentsUsingTask> {
         appendToSubjectTask("setEnvironmentDefaults()")
 
         and: "a test value in system env"
-        initialValue.each { key, value ->
-            environmentVariables.set(key, value)
+        initialValue.each { key, v ->
+            environmentVariables.set(key, v)
         }
 
         appendToSubjectTask("$method(${wrapValueBasedOnType(rawValue, Map)})")


### PR DESCRIPTION
## Description

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

## Changes

* ![ADD] `snyk` monitoring

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
