### PR TITLE
Add back getValue methods which were removed

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -159,6 +159,14 @@ class PropertyLookup {
         getDefaultValue()
     }
 
+    Object getValue(Project project) {
+        getValue(project.properties, null)
+    }
+
+    Object getValue() {
+        getValue(null, null)
+    }
+
     private static Object extractValue(Object value) {
         if (value == null) {
             return null

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
@@ -209,4 +209,23 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         "hot"              | "cold"            | SuperCoolEnum.cold
         SuperCoolEnum.cold | SuperCoolEnum.hot | SuperCoolEnum.hot
     }
+
+
+    def "gets property value from project's properties"() {
+        given: "a property lookup"
+        def lookup = new PropertyLookup(null, propertyKey, null)
+
+        and: "a value in the project"
+        project.extensions.add(propertyKey, propertyValue)
+
+        when:
+        def actual = lookup.getValue(project)
+
+        then:
+        actual == propertyValue
+
+        where:
+        propertyKey | propertyValue
+        "foo"       | "bar"
+    }
 }

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupSpec.groovy
@@ -103,5 +103,19 @@ class PropertyLookupSpec extends Specification {
         props = ["bread.ham": 7]
         env = ["BREAD_HAM": 7]
     }
+
+    def "gets default value"() {
+        given: "a property lookup"
+        def lookup = new PropertyLookup(propertyValue)
+
+        when:
+        def actual = lookup.getValue()
+
+        then:
+        actual == propertyValue
+
+        where:
+        propertyValue = "bar"
+    }
 }
 


### PR DESCRIPTION
## Description

Adds missing `PropertyLookup` `getValue` methods

## Changes
* ![ADD] Missing `getValue` methods in `PropertyLookup`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
