### PR TITLE
Fix envNameFromProperty when numbers are part of the name

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyUtils.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyUtils.groovy
@@ -16,7 +16,7 @@ class PropertyUtils {
      * @return A generated environment key based from the property path
      */
     static String envNameFromProperty(String property) {
-        property.replaceAll(/([A-Z.])/, '_$1').replaceAll(/[.]/, '').toUpperCase()
+        property.replaceAll(/([A-Z.]|[0-9]+)/, '_$1').replaceAll(/[.]/, '').toUpperCase()
     }
 
     /**
@@ -24,7 +24,7 @@ class PropertyUtils {
      * @return A string, in camel case. (helloThereBrownCow)
      */
     static String toCamelCase(String input) {
-        input.replaceAll(/\(\)/,"").replaceAll(/((\/|-|_|\.)+)([\w])/, { all, delimiterAll, delimiter, firstAfter -> "${firstAfter.toUpperCase()}" })
+        input.replaceAll(/\(\)/,"").toLowerCase().replaceAll(/((\/|-|_|\.)+)([\w])/, { all, delimiterAll, delimiter, firstAfter -> "${firstAfter.toUpperCase()}" })
     }
 
     /**

--- a/src/test/groovy/com/wooga/gradle/PropertyUtilsSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyUtilsSpec.groovy
@@ -5,28 +5,58 @@ import spock.lang.Unroll
 
 class PropertyUtilsSpec extends Specification {
 
+    @Unroll
     def "environment name is converted from extension and property name"() {
-        when:
-        def environmentName = PropertyUtils.envNameFromProperty(extensionName, propertyName)
-
-        then:
-        environmentName == expectedEnvironmentName
+        expect:
+        PropertyUtils.envNameFromProperty(extensionName, propertyName) == expectedEnvironmentName
 
         where:
-        extensionName | propertyName | expectedEnvironmentName
-        "foobar"      | "kat.zen"    | "FOOBAR_KAT_ZEN"
+        extensionName | propertyName          || expectedEnvironmentName
+        "foobar"      | "kat.zen"             || "FOOBAR_KAT_ZEN"
+        "foobar"      | "fooBar"              || "FOOBAR_FOO_BAR"
+        "foobar"      | "foo.bar"             || "FOOBAR_FOO_BAR"
+        "foobar"      | "fooBar.barFoo"       || "FOOBAR_FOO_BAR_BAR_FOO"
+        "foobar"      | "foo2Bar.bar2Foo"     || "FOOBAR_FOO_2_BAR_BAR_2_FOO"
+        "foobar"      | "foo2bar.bar2foo"     || "FOOBAR_FOO_2BAR_BAR_2FOO"
+        "foobar"      | "foo44Bar.bar5555Foo" || "FOOBAR_FOO_44_BAR_BAR_5555_FOO"
+        "foobar"      | "foo22bar.bar2222foo" || "FOOBAR_FOO_22BAR_BAR_2222FOO"
     }
 
+    @Unroll
     def "environment name is converted from property name"() {
-        when:
-        def environmentName = PropertyUtils.envNameFromProperty(propertyName)
-
-        then:
-        environmentName == expectedEnvironmentName
+        expect:
+        PropertyUtils.envNameFromProperty(propertyName) == expectedEnvironmentName
 
         where:
-        propertyName | expectedEnvironmentName
-        "kat.zen"    | "KAT_ZEN"
+        propertyName          || expectedEnvironmentName
+        "fooBar"              || "FOO_BAR"
+        "foo.bar"             || "FOO_BAR"
+        "fooBar.barFoo"       || "FOO_BAR_BAR_FOO"
+        "foo2Bar.bar2Foo"     || "FOO_2_BAR_BAR_2_FOO"
+        "foo2bar.bar2foo"     || "FOO_2BAR_BAR_2FOO"
+        "foo44Bar.bar5555Foo" || "FOO_44_BAR_BAR_5555_FOO"
+        "foo22bar.bar2222foo" || "FOO_22BAR_BAR_2222FOO"
+    }
+
+    @Unroll
+    def "toCamelCase converts '#input' to camel case '#expectedValue"() {
+        expect:
+        PropertyUtils.toCamelCase(input) == expectedValue
+
+        where:
+        input                     || expectedValue
+        "FOO_BAR"                 || "fooBar"
+        "FOO_BAR_BAR_FOO"         || "fooBarBarFoo"
+        "FOO_2_BAR_BAR_2_FOO"     || "foo2BarBar2Foo"
+        "FOO_2BAR_BAR_2FOO"       || "foo2barBar2foo"
+        "FOO_44_BAR_BAR_5555_FOO" || "foo44BarBar5555Foo"
+        "FOO_22BAR_BAR_2222FOO"   || "foo22barBar2222foo"
+        "foo_bar"                 || "fooBar"
+        "foo_bar_bar_foo"         || "fooBarBarFoo"
+        "foo_2_bar_bar_2_foo"     || "foo2BarBar2Foo"
+        "foo_2bar_bar_2foo"       || "foo2barBar2foo"
+        "foo_44_bar_bar_5555_foo" || "foo44BarBar5555Foo"
+        "foo_22bar_bar_2222foo"   || "foo22barBar2222foo"
     }
 
     @Unroll


### PR DESCRIPTION
## Description

The helper method `envNameFromProperty` creates incorrect outputs when the given propertyname contains numbers eg. `foo.bar22Bar`. The expected result should be `FOO_BAR_22_BAR`.

I fixed the method with this patch and adjusted the tests. I also made sure that the `toCamelCase` converts to lowercase before splitting the values.

## Changes

* ![FIX] `envNameFromProperty` utility method
* ![FIX] `toCamelCase` utility method

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
