### PR TITLE
Adds some useful methods when working with PropertyLookups

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -18,14 +18,12 @@ package com.wooga.gradle
 
 
 import org.gradle.api.Project
-import org.gradle.api.Transformer
 import org.gradle.api.file.Directory
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 
-import javax.naming.spi.ObjectFactory
 import java.util.concurrent.Callable
 import java.util.function.Function
 
@@ -44,7 +42,7 @@ class PropertyLookup {
      */
     final List<String> environmentKeys
     /**
-     * Provided property keys
+     * Provided gradle property keys
      */
     final List<String> propertyKeys
     /**
@@ -151,7 +149,7 @@ class PropertyLookup {
         }
 
         // If provided, return the given default value
-        if (defaultValue != null){
+        if (defaultValue != null) {
             return defaultValue
         }
 
@@ -336,13 +334,46 @@ class PropertyLookup {
      * @return A provider which returns an enum of type {#code T}, casting from string when needed
      */
     public <T> Provider<T> getEnumValueProvider(Project project, Class<T> enumClass, Object defaultValue = null) {
-        if (!enumClass.enum){
+        if (!enumClass.enum) {
             throw new Exception("${enumClass} is not an enumeration type!")
         }
 
         getObjectValueProvider(project, defaultValue).map({
             def enumValue = enumClass.invokeMethod("valueOf", it.toString())
             enumValue
-        })  as Provider<T>
+        }) as Provider<T>
+    }
+
+    //------------------------------------------------------------------------/
+    // Static Utilities
+    //------------------------------------------------------------------------/
+    /**
+     * @return All the property lookups declared in the given class
+     */
+    static List<PropertyLookup> getAll(Class type) {
+        type.declaredFields.findAll({ it.type == PropertyLookup }).collect({
+            it.setAccessible(true)
+            def convention = (PropertyLookup) it.get()
+            it.setAccessible(false)
+            convention
+        })
+    }
+
+    /**
+     * @return All the environment variables (by their keys) declared by property lookups on the given class
+     */
+    static List<String> getEnvironmentVariables(Class type) {
+        getAll(type).collect {
+            it.environmentKeys as List<String>
+        }.flatten() as List<String>
+    }
+
+    /**
+     * @return All the gradle project properties (by their keys) declared by property lookups on the given class
+     */
+    static List<String> getGradleProperties(Class type) {
+        getAll(type).collect {
+            it.propertyKeys as List<String>
+        }.flatten() as List<String>
     }
 }

--- a/src/test/groovy/com/wooga/gradle/MockIntegrationSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/MockIntegrationSpec.groovy
@@ -112,7 +112,6 @@ abstract class MockTaskIntegrationSpec<T extends MockTask> extends MockIntegrati
 class MockPlugin implements Plugin<Project> {
 
     static final String extensionName = "commons"
-    static final String taskName = "mock"
 
     @Override
     void apply(Project project) {
@@ -125,6 +124,26 @@ class MockPlugin implements Plugin<Project> {
 class MockExtension {
 }
 
-class MockTask extends DefaultTask {
+class MockConventions {
+
+    static final PropertyLookup name = new PropertyLookup(
+        "MOCK_NAME",
+        "mock.name",
+        "foobar"
+    )
+
+    static final PropertyLookup version = new PropertyLookup(
+        "MOCK_VERSION",
+        "mock.version",
+        "latest"
+    )
+
+    static final PropertyLookup directory = new PropertyLookup(
+        "MOCK_DIR",
+        "mock.dir",
+        null
+    )
 }
 
+class MockTask extends DefaultTask {
+}

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupSpec.groovy
@@ -1,14 +1,6 @@
 package com.wooga.gradle
 
-import com.wooga.gradle.io.LogFileSpec
-import com.wooga.gradle.io.OutputStreamSpec
-import com.wooga.gradle.test.PropertyQueryTaskWriter
-import nebula.test.ProjectSpec
-import org.gradle.api.Action
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.TaskAction
-import org.gradle.process.ExecResult
-import org.gradle.process.ExecSpec
+
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -116,6 +108,33 @@ class PropertyLookupSpec extends Specification {
 
         where:
         propertyValue = "bar"
+    }
+
+    def "gets all property lookups from mock conventions class"() {
+        when:
+        def lookups = PropertyLookup.getAll(MockConventions)
+
+        then:
+        lookups.size() == 3
+        lookups.containsAll(MockConventions.name, MockConventions.version, MockConventions.directory)
+    }
+
+    def "gets all environment variables from mock conventions class"() {
+        when:
+        def envVars = PropertyLookup.getEnvironmentVariables(MockConventions)
+
+        then:
+        envVars.size() == 3
+        envVars.containsAll("MOCK_NAME", "MOCK_VERSION", "MOCK_DIR")
+    }
+
+    def "gets all properties from mock conventions class"() {
+        when:
+        def properties = PropertyLookup.getGradleProperties(MockConventions)
+
+        then:
+        properties.size() == 3
+        properties.containsAll("mock.name", "mock.version", "mock.dir")
     }
 }
 

--- a/src/test/groovy/com/wooga/gradle/PropertyUtilsSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyUtilsSpec.groovy
@@ -81,8 +81,6 @@ class PropertyUtilsSpec extends Specification {
         "foo"         | "setFoo"
         "foo.bar"     | "foo.setBar"
         "foo.bar.baz" | "foo.bar.setBaz"
-
     }
-
-
 }
+


### PR DESCRIPTION
## Description

Added a few static utility methods developed by a colleague while he was working on a project; these will prove useful both for a generic base plugin class and for the integration specs to clear environment variables with. They are:

* `getAll(Class)`: Retrieves all the PropertyLookup fields on the given class
* `getEnvironmentVariables(Class)`: Retrieves all the environment variables declared by PropertyLookup fields on the given class
* `getGradleProperties(Class)`: Retrieves all the gradle properties declared by PropertyLookup fields on the given class

## Changes
* ![UPDATE] PropertyLookup: Static methods for looking up property lookups on a given class

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
