### PR TITLE
File-like property lookup now can change base directory

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -273,40 +273,44 @@ class PropertyLookup {
     /**
      * @return A provider which returns a {@code RegularFile}
      */
-    Provider<RegularFile> getFileValueProvider(ProviderFactory factory, ProjectLayout layout, Map<String, ?> properties, Map<String, ?> env = null, Object defaultValue = null) {
-        layout.buildDirectory.file(
-            factory.provider({
-                getValueAsString(properties, env, defaultValue)
-            })
-        )
+    Provider<RegularFile> getFileValueProvider(ProviderFactory factory, ProjectLayout layout, Map<String, ?> properties,
+                                               Map<String, ?> env = null, Object defaultValue = null, Provider<Directory> baseDir = layout.buildDirectory) {
+
+        // We can get rid of the factory here, by just returning the "baseDir.map..." expression. But removing it would be a breaking change, so its better to keep it here for now.
+        // We could just keep the factory unused as well, but I believe if someone is passing a factory to a function it would want that factory creating his providers, so...
+        factory.provider {
+            baseDir.map{it.file(getValueAsString(properties, env, defaultValue)) }
+        }.flatMap{it}
     }
 
     /**
      * @return A provider which returns a {@code RegularFile}
      */
-    Provider<RegularFile> getFileValueProvider(Project project, Object defaultValue = null) {
+    Provider<RegularFile> getFileValueProvider(Project project, Object defaultValue = null, Provider<Directory> baseDir = project.layout.buildDirectory) {
         project.provider({
-            getFileValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue)
+            getFileValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue, baseDir)
         }).flatMap({ it })
     }
 
     /**
      * @return A provider which returns a {@code Directory}
      */
-    Provider<Directory> getDirectoryValueProvider(ProviderFactory factory, ProjectLayout layout, Map<String, ?> properties, Map<String, ?> env = null, Object defaultValue = null) {
-        layout.buildDirectory.dir(
-            factory.provider({
-                getValueAsString(properties, env, defaultValue)
-            })
-        )
+    Provider<Directory> getDirectoryValueProvider(ProviderFactory factory, ProjectLayout layout, Map<String, ?> properties,
+                                                  Map<String, ?> env = null, Object defaultValue = null, Provider<Directory> baseDir = layout.buildDirectory) {
+        // We can get rid of the factory here, by just returning the "baseDir.map..." expression. But removing it would be a breaking change, so its better to keep it here for now.
+        // We could just keep the factory unused as well, but I believe if someone is passing a factory to a function it would want that factory creating his providers, so...
+        factory.provider {
+            baseDir.map{it.dir(getValueAsString(properties, env, defaultValue)) }
+        }.flatMap {it}
+
     }
 
     /**
      * @return A provider which returns a {@code Directory}
      */
-    Provider<Directory> getDirectoryValueProvider(Project project, Object defaultValue = null) {
+    Provider<Directory> getDirectoryValueProvider(Project project, Object defaultValue = null, Provider<Directory> baseDir = project.layout.buildDirectory) {
         project.provider({
-            getDirectoryValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue)
+            getDirectoryValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue, baseDir)
         }).flatMap({ it })
     }
 

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
@@ -1,6 +1,8 @@
 package com.wooga.gradle
 
 import nebula.test.ProjectSpec
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
 import spock.lang.Unroll
 
 class PropertyLookupProviderSpec extends ProjectSpec {
@@ -228,4 +230,49 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         propertyKey | propertyValue
         "foo"       | "bar"
     }
+
+    @Unroll
+    def "gets file property value relative to base directory"() {
+        given: "a property lookup"
+        def lookup = new PropertyLookup(value)
+
+        and: "a file provider for it"
+        def baseDir = project.provider { baseDirFactory(project) as Directory }
+        def provider = lookup.getFileValueProvider(project, null, baseDir)
+
+        when:
+        def actual = provider.get()
+
+        then:
+        def expected = baseDir.map { it.file(value) }.get()
+        expected == actual
+
+        where:
+        value       | baseDirFactory
+        "file"      | { Project p -> p.layout.projectDirectory }
+        "otherFile" | { Project p -> p.layout.projectDirectory.dir("dir") }
+    }
+
+    @Unroll
+    def "gets directory property value relative to base directory"() {
+        given: "a property lookup"
+        def lookup = new PropertyLookup(value)
+
+        and: "a file provider for it"
+        def baseDir = project.provider { baseDirFactory(project) as Directory }
+        def provider = lookup.getDirectoryValueProvider(project, null, baseDir)
+
+        when:
+        def actual = provider.get()
+
+        then:
+        def expected = baseDir.map { it.dir(value) }.get()
+        expected == actual
+
+        where:
+        value    | baseDirFactory
+        "dir"    | { Project p -> p.layout.projectDirectory }
+        "subdir" | { Project p -> p.layout.projectDirectory.dir("dir") }
+    }
+
 }


### PR DESCRIPTION
## Description
`PropertyLookup` methods for fetching `File` and `Directory` values were hardcoded to always fetch from the `buildDirectory` directory. This PR adds an extra optional argument to the get method for those values, and now `buildDirectory` can be replaced by another base directory if so desired.

## Changes
* ![IMPROVE] Added `baseDir` parameter to File-like PropertyLookup methods.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
