### PR TITLE
Fixes property lookup for files and dirs on null cases

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -278,18 +278,16 @@ class PropertyLookup {
 
         // We can get rid of the factory here, by just returning the "baseDir.map..." expression. But removing it would be a breaking change, so its better to keep it here for now.
         // We could just keep the factory unused as well, but I believe if someone is passing a factory to a function it would want that factory creating his providers, so...
-        factory.provider {
-            baseDir.map{it.file(getValueAsString(properties, env, defaultValue)) }
-        }.flatMap{it}
+        baseDir.flatMap {
+            it.file(factory.provider { getValueAsString(properties, env, defaultValue) })
+        }
     }
 
     /**
      * @return A provider which returns a {@code RegularFile}
      */
     Provider<RegularFile> getFileValueProvider(Project project, Object defaultValue = null, Provider<Directory> baseDir = project.layout.buildDirectory) {
-        project.provider({
-            getFileValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue, baseDir)
-        }).flatMap({ it })
+        return getFileValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue, baseDir)
     }
 
     /**
@@ -299,19 +297,16 @@ class PropertyLookup {
                                                   Map<String, ?> env = null, Object defaultValue = null, Provider<Directory> baseDir = layout.buildDirectory) {
         // We can get rid of the factory here, by just returning the "baseDir.map..." expression. But removing it would be a breaking change, so its better to keep it here for now.
         // We could just keep the factory unused as well, but I believe if someone is passing a factory to a function it would want that factory creating his providers, so...
-        factory.provider {
-            baseDir.map{it.dir(getValueAsString(properties, env, defaultValue)) }
-        }.flatMap {it}
-
+        baseDir.flatMap{
+            it.dir(factory.provider { getValueAsString(properties, env, defaultValue) })
+        }
     }
 
     /**
      * @return A provider which returns a {@code Directory}
      */
     Provider<Directory> getDirectoryValueProvider(Project project, Object defaultValue = null, Provider<Directory> baseDir = project.layout.buildDirectory) {
-        project.provider({
-            getDirectoryValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue, baseDir)
-        }).flatMap({ it })
+        return getDirectoryValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue, baseDir)
     }
 
     /**

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
@@ -241,14 +241,15 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         def provider = lookup.getFileValueProvider(project, null, baseDir)
 
         when:
-        def actual = provider.get()
+        def actual = provider.orNull
 
         then:
-        def expected = baseDir.map { it.file(value) }.get()
+        def expected = value? baseDir.get().file(value) : null
         expected == actual
 
         where:
         value       | baseDirFactory
+        null        | { Project p -> p.layout.projectDirectory }
         "file"      | { Project p -> p.layout.projectDirectory }
         "otherFile" | { Project p -> p.layout.projectDirectory.dir("dir") }
     }
@@ -263,14 +264,15 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         def provider = lookup.getDirectoryValueProvider(project, null, baseDir)
 
         when:
-        def actual = provider.get()
+        def actual = provider.orNull
 
         then:
-        def expected = baseDir.map { it.dir(value) }.get()
+        def expected = value? baseDir.get().dir(value) : null
         expected == actual
 
         where:
         value    | baseDirFactory
+        null     | { Project p -> p.layout.projectDirectory }
         "dir"    | { Project p -> p.layout.projectDirectory }
         "subdir" | { Project p -> p.layout.projectDirectory.dir("dir") }
     }


### PR DESCRIPTION
## Description
`getFileValueProvider`/`getDirectoryValueProvider` were returning providers instead of null on `get()` (even though type assertion should prevent this kind of concentrated fun juice, but i digress). 
This was fixed by reordering the provider resolution to assert that `dir(...)` or `file(...)` always receive a provider as parameter.

 


## Changes
* ![FIX] `PropertyLookup` `getFileValueProvider` and `getDirectoryValueProvider`  returning unexpected type on provider `get()`.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
