### PR TITLE
Add missing wrap for the file provider

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -287,7 +287,12 @@ class PropertyLookup {
      * @return A provider which returns a {@code RegularFile}
      */
     Provider<RegularFile> getFileValueProvider(Project project, Object defaultValue = null, Provider<Directory> baseDir = project.layout.buildDirectory) {
-        return getFileValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue, baseDir)
+        // We need to wrap this call into another provider to guard from eager evaluation of project.properties.
+        // There are test setups via nebular test which sometimes create the project base dir at a later time and
+        // the access to project.properties results in an exception.
+        project.provider({
+            getFileValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue, baseDir)
+        }).flatMap({it})
     }
 
     /**


### PR DESCRIPTION
## Description

Fixes an issue that arises when trying to generate a file provider from the property lookup. If the property being used for the default value is evaluated too early. Hence, we wrap the provider in a provider.

## Changes
* ![UPDATE] `PropertyLookup`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
