### PR TITLE
Let the enum value provider handle null/empty inputs

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -348,6 +348,10 @@ class PropertyLookup {
         }
 
         getObjectValueProvider(project, defaultValue).map({
+            def stringValue = it.toString()
+            if (stringValue == null || stringValue.empty) {
+                return defaultValue
+            }
             def enumValue = enumClass.invokeMethod("valueOf", it.toString())
             enumValue
         }) as Provider<T>

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
@@ -199,7 +199,7 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         def provider = lookup.getEnumValueProvider(project, SuperCoolEnum.class, defaultValue)
 
         when:
-        def actual = provider.get()
+        def actual = provider.getOrNull()
 
         then:
         actual == expected
@@ -210,6 +210,9 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         SuperCoolEnum.cold | null              | SuperCoolEnum.cold
         "hot"              | "cold"            | SuperCoolEnum.cold
         SuperCoolEnum.cold | SuperCoolEnum.hot | SuperCoolEnum.hot
+        ""                 | null              | null
+        ""                 | "cold"            | SuperCoolEnum.cold
+        null               | null              | null
     }
 
 
@@ -244,7 +247,7 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         def actual = provider.orNull
 
         then:
-        def expected = value? baseDir.get().file(value) : null
+        def expected = value ? baseDir.get().file(value) : null
         expected == actual
 
         where:
@@ -267,7 +270,7 @@ class PropertyLookupProviderSpec extends ProjectSpec {
         def actual = provider.orNull
 
         then:
-        def expected = value? baseDir.get().dir(value) : null
+        def expected = value ? baseDir.get().dir(value) : null
         expected == actual
 
         where:


### PR DESCRIPTION
## Description
Let the `PropertyLookup.getEnumValueProvider` handle null/empty strings, by returning the default value. This will allow plugins to handle these values being set by pipelines in an elegant way.

## Changes
* ![IMPROVE] `PropertyLookup.getEnumValueProvider` : Handle null/empty strings by returning the default value.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
