### PR TITLE
Add a List<String> value provider to property lookup

### DIFF
--- a/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
+++ b/src/main/groovy/com/wooga/gradle/PropertyLookup.groovy
@@ -235,6 +235,29 @@ class PropertyLookup {
     }
 
     /**
+     * @return A provider which returns a {@code String}
+     */
+    Provider<List<String>> getListStringValueProvider(ProviderFactory factory, Map<String, ?> properties, Map<String, ?> env = null, Object defaultValue = null) {
+        factory.provider({
+            // Convert the raw value to List<String>
+            def value = getValueAsString(properties, env, defaultValue)
+            if (value == null || value == "") {
+                return null
+            }
+            value.tokenize(',;|[]')
+        })
+    }
+
+    /**
+     * @return A provider which returns a {@code List<String>}
+     */
+    Provider<List<String>> getListStringValueProvider(Project project, Object defaultValue = null) {
+        project.provider({
+            getListStringValueProvider(project.getProviders(), project.properties, System.getenv(), defaultValue)
+        }).flatMap({ it })
+    }
+
+    /**
      * @return A provider which returns a {@code Boolean}
      */
     Provider<Boolean> getBooleanValueProvider(ProviderFactory factory, Map<String, ?> properties, Map<String, ?> env = null, Object defaultValue = null) {
@@ -292,7 +315,7 @@ class PropertyLookup {
         // the access to project.properties results in an exception.
         project.provider({
             getFileValueProvider(project.providers, project.layout, project.properties, System.getenv(), defaultValue, baseDir)
-        }).flatMap({it})
+        }).flatMap({ it })
     }
 
     /**

--- a/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/PropertyLookupProviderSpec.groovy
@@ -58,6 +58,35 @@ class PropertyLookupProviderSpec extends ProjectSpec {
     }
 
     @Unroll
+    def "sets `#value`, gets value `#expected` List<String> provider"() {
+
+        given: "a property lookup"
+        def lookup = new PropertyLookup(value)
+
+        and: "a provider for it"
+        def provider = lookup.getListStringValueProvider(project, defaultValue)
+
+        when:
+        def actual = provider.getOrNull()
+
+        then:
+        expected == actual
+
+        where:
+        value              | expected                 | defaultValue
+        "foobar"           | ["foobar"]               | null
+        "foobar"           | ["barfoo"]               | "barfoo"
+        "[foobar]"         | ["foobar"]               | null
+        "foo,bar"          | ["foo", "bar"]           | null
+        "[foo,bar]"        | ["foo", "bar"]           | null
+        "foo;bar;foobar"   | ["foo", "bar", "foobar"] | null
+        "[foo;bar;foobar]" | ["foo", "bar", "foobar"] | null
+        ""                 | null                     | null
+        null               | null                     | null
+        null               | ["barfoo"]               | "barfoo"
+    }
+
+    @Unroll
     def "gets value `#expected` from boolean provider"() {
 
         given: "a property lookup"


### PR DESCRIPTION
## Description
Adds a List<String> value provider to property lookup, as there are cases where we want to set them.

## Changes
* ![ADD] `PropertyLookup` : Add the List<String> value provider

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
