### PR TITLE
Fix the issue where ExecSpec.getExecutableDirectory was evaluating too early [ATLAS-1396]

### DIFF
--- a/src/main/groovy/com/wooga/gradle/io/ExecSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/io/ExecSpec.groovy
@@ -33,12 +33,9 @@ trait ExecSpec implements BaseSpec {
      */
     @Input
     Provider<String> getExecutable() {
-        if (executableDirectory.present) {
-            return executableDirectory.file(executableName).map {
-                it.asFile.absolutePath
-            }
-        }
-        return executableName
+        return executableDirectory.file(executableName).map {
+            it.asFile.absolutePath
+        }.orElse(executableName)
     }
 
     /**

--- a/src/test/groovy/com/wooga/gradle/MockPlugin.groovy
+++ b/src/test/groovy/com/wooga/gradle/MockPlugin.groovy
@@ -1,0 +1,61 @@
+package com.wooga.gradle
+
+import com.wooga.gradle.io.ExecSpec
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+import java.lang.reflect.ParameterizedType
+
+class MockPlugin<T extends MockExtension> implements Plugin<Project> {
+
+    Class<T> getExtensionClass() {
+        if (!_extensionClass) {
+            try {
+                _extensionClass = (Class<T>) ((ParameterizedType) this.getClass().getGenericSuperclass())
+                    .getActualTypeArguments()[0];
+            }
+            catch (Exception e) {
+                _extensionClass = (Class<T>) MockExtension
+            }
+        }
+        _extensionClass
+    }
+    private Class<T> _extensionClass
+
+    static final String extensionName = "commons"
+
+    @Override
+    void apply(Project project) {
+        def extension = project.extensions.create(extensionClass, extensionName, extensionClass)
+        apply(project, extension)
+        project.tasks.withType(MockTask).configureEach { t ->
+        }
+    }
+
+    void apply(Project project, T extension) {
+    }
+}
+
+class MockExtension implements ExecSpec {
+}
+
+class MockConventions {
+
+    static final PropertyLookup name = new PropertyLookup(
+        "MOCK_NAME",
+        "mock.name",
+        "foobar"
+    )
+
+    static final PropertyLookup version = new PropertyLookup(
+        "MOCK_VERSION",
+        "mock.version",
+        "latest"
+    )
+
+    static final PropertyLookup directory = new PropertyLookup(
+        "MOCK_DIR",
+        "mock.dir",
+        null
+    )
+}

--- a/src/test/groovy/com/wooga/gradle/io/ExecSpecImplTask.groovy
+++ b/src/test/groovy/com/wooga/gradle/io/ExecSpecImplTask.groovy
@@ -186,4 +186,3 @@ class ExecSpecImplTaskIntegrationSpec extends MockTaskIntegrationSpec<ExecSpecIm
         "oh yes" | "oh no" | File.createTempFile("stdout", ".log") | File.createTempFile("stderr", ".log") | true        | true
     }
 }
-

--- a/src/test/groovy/com/wooga/gradle/io/ExecSpecPluginUsageIntegrationSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/io/ExecSpecPluginUsageIntegrationSpec.groovy
@@ -1,0 +1,62 @@
+package com.wooga.gradle.io
+
+import com.wooga.gradle.MockExtension
+import com.wooga.gradle.MockIntegrationSpec
+import com.wooga.gradle.MockPlugin
+import com.wooga.gradle.MockPluginIntegrationSpec
+import com.wooga.gradle.test.queries.TestValue
+import com.wooga.gradle.test.writers.PropertyGetterTaskWriter
+import org.gradle.api.Project
+import spock.lang.Unroll
+
+class ExtensionWithExec extends MockExtension implements ExecSpec {
+}
+
+class MockPluginWithExtension extends MockPlugin<ExtensionWithExec> {
+    @Override
+    void apply(Project project, ExtensionWithExec extension) {
+        project.tasks.withType(ExecSpecImplTask).configureEach { t ->
+            t.setExecutable(extension.executable)
+        }
+    }
+}
+
+class ExecSpecPluginUsageIntegrationSpec extends MockPluginIntegrationSpec<MockPluginWithExtension> {
+
+    private static String defaultExecutableName = "fork"
+
+    @Unroll
+    def "when #inputProperty is set to #inputValue, then #outputProperty is evaluated at the right time"() {
+
+        given: "a configured extension with defaults"
+        appendToExtension("""
+        executableName = ${wrapValueBasedOnType(defaultExecutableName, String)}
+        """.stripIndent())
+
+        if (inputValue != null) {
+            appendToExtension("${inputProperty} = ${wrapValueBasedOnType(inputValue, type)}".stripIndent())
+        }
+
+        and: "a task that should be mapped"
+        addTask(taskName, ExecSpecImplTask, true)
+
+        expect:
+        if (outputValue == _) {
+            outputValue = inputValue
+        }
+        runPropertyQuery(getter).matches(outputValue)
+
+        where:
+        inputProperty         | inputValue     | type   | outputProperty   | outputValue
+        "executableDirectory" | null           | File   | "executable"     | defaultExecutableName
+        "executableDirectory" | "usr/bin/asdf" | File   | "executable"     | TestValue.projectFile("usr/bin/asdf/fork")
+        "executable"          | "foobar"       | String | "executable"     | _
+        "executable"          | "foobar"       | String | "executableName" | _
+        "executableName"      | null           | String | "executable"     | defaultExecutableName
+        "executableName"      | "foobar"       | String | "executable"     | _
+        "executableName"      | "foobar"       | String | "executableName" | _
+
+        taskName = "pancakeLord"
+        getter = new PropertyGetterTaskWriter("${taskName}.${outputProperty}")
+    }
+}


### PR DESCRIPTION
## Description

The `ExecSpec.getExecutableDirectory` was evaluating too early, which causes issues.

## Changes
* ![FIX] `ExecSpec.getExecutableDirectory`  was evaluating too early

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
